### PR TITLE
Fix errors in grid coefficients for several azure regions

### DIFF
--- a/data/grid-emissions-factors-azure.csv
+++ b/data/grid-emissions-factors-azure.csv
@@ -19,7 +19,7 @@ West India,Mumbai,,0.000708,carbonfootprint.com
 UK South,London,,0.000228,EEA
 UK West,Cardiff,,0.000228,EEA
 France Central,Paris,,0.000067,EEA
-Finland Central,Helsinki,,000077,EEA,
-Germany West Central,Frankfurt,,000402,EEA
+Finland Central,Helsinki,,0.000077,EEA,
+Germany West Central,Frankfurt,,0.000402,EEA
 Belgium Central,Brussels,,0.000154,EEA
 Sweden Central,Gavle,,0.000009,EEA


### PR DESCRIPTION
Hello,

This pull request fixes several error in the grid emissions factor of several azure regions. For several emission factors, `0.` is missing at the beginning of the value. As I was the person who introduced these values in the original git repository, I can assure that the values are wrong and should be corrected this way.

Sorry for having introduced these errors.

Best Regards,

Jonathan Pastor